### PR TITLE
"data-confirm" with form inconsistent

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -172,8 +172,11 @@
   });
 
   document.on("click", "form input[type=submit], form button[type=submit], form button:not([type])", function(event, button) {
+    var form = event.findElement('form');
     // register the pressed submit button
-    event.findElement('form').store('rails:submit-button', button.name || false);
+    form.store('rails:submit-button', button.name || false);
+    // allowAction() checks the form element in on submit event
+    form.writeAttribute('data-confirm', button.readAttribute('data-confirm'));
   });
 
   document.on("submit", function(event) {


### PR DESCRIPTION
prototype-ujs expects that the `data-confirm` be on the form element rather than the submit button. `button_to` helper in rails adds it to the submit input. As well, I believe the jquery-ujs driver expects the attribute on the submit input. 

I don't think my fix is an end all as it's pretty flawed (if you have existing forms with data-confirm) but may work as a quick fix for folks running into this. Anyway, a heads up on the issue.
