### PR TITLE
Passed along any original 'target' attribute to the generated form tag in handleMethod()

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -121,10 +121,11 @@
   function handleMethod(element) {
     var method = element.readAttribute('data-method'),
         url = element.readAttribute('href'),
+        target = element.readAttribute('target') || "",
         csrf_param = $$('meta[name=csrf-param]')[0],
         csrf_token = $$('meta[name=csrf-token]')[0];
 
-    var form = new Element('form', { method: "POST", action: url, style: "display: none;" });
+    var form = new Element('form', { method: "POST", action: url, style: "display: none;", target: target });
     $(element.parentNode).insert(form);
 
     if (method !== 'post') {


### PR DESCRIPTION
Passed along any original 'target' attribute to the generated form tag in handleMethod(). Fixes https://github.com/rails/rails/issues/2885 for prototype-ujs.

Also made pull request for jquery-ujs: https://github.com/rails/jquery-ujs/pull/207. Is there any other JS file, perhaps in rails itself, to update for this feature?
