### PR TITLE
Fix confirm dialogs not triggering on form submission

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -172,6 +172,10 @@
   });
 
   document.on("click", "form input[type=submit], form button[type=submit], form button:not([type])", function(event, button) {
+    if (!allowAction(button)) {
+      event.stop();
+      return false;
+    }
     // register the pressed submit button
     event.findElement('form').store('rails:submit-button', button.name || false);
   });


### PR DESCRIPTION
Add allowAction() to form button click handler
