### PR TITLE
Links created with a data-method or data-remote attribute submit via right click

### DIFF
--- a/src/rails.js
+++ b/src/rails.js
@@ -157,17 +157,19 @@
   }
 
   document.on('click', 'a[data-confirm], a[data-remote], a[data-method]', function(event, link) {
-    if (!allowAction(link)) {
-      event.stop();
-      return false;
-    }
+    if (Event.isLeftClick(event)) {
+      if (!allowAction(link)) {
+        event.stop();
+        return false;
+      }
 
-    if (link.readAttribute('data-remote')) {
-      handleRemote(link);
-      event.stop();
-    } else if (link.readAttribute('data-method')) {
-      handleMethod(link);
-      event.stop();
+      if (link.readAttribute('data-remote')) {
+        handleRemote(link);
+        event.stop();
+      } else if (link.readAttribute('data-method')) {
+        handleMethod(link);
+        event.stop();
+      }
     }
   });
 


### PR DESCRIPTION
Although `$('link').on('click', function(event) { ... })` only responds to left clicks, `document.on('click', '[selector]', function(event, el) { ... })` responds to right click as well, which has the byproduct of causing remote links or links with a method specified to submit when right clicked on.
